### PR TITLE
Update require-labels.yml

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v1
+      - uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly
           count: 1


### PR DESCRIPTION
Updated to latest v5 version due to deprecation of Node 12.js

label / label
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: mheap/github-action-required-labels@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.