### PR TITLE
Npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,17 +191,17 @@ jobs:
           name: ${{ inputs.artifacts_download_name }}
           path: ${{ inputs.artifacts_download_path }}
           merge-multiple: true
-          
+      
+      - name: Start npm
+        if: ${{ (fromJson(steps.skip-build.outputs.skip) == false) && (inputs.start_npm == true) }} 
+        run: |
+          npm set @databox:registry=https://npm.pkg.github.com/databox
+          npm set //npm.pkg.github.com/:_authToken=${{ secrets.PACKAGES_READ_TOKEN }}
+          npm start
+
       - name: Docker build and push ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
         if: ${{ !fromJson(steps.skip-build.outputs.skip) }}
         run: |
-        
-          if [[ "${{ inputs.start_npm }}" == true ]]; then
-            npm set @databox:registry=https://npm.pkg.github.com/databox
-            npm set //npm.pkg.github.com/:_authToken=${{ secrets.PACKAGES_READ_TOKEN }}
-            npm start
-          fi
-          
           docker buildx create --name DLC_builder --use --driver=docker-container
           docker buildx build \
             ${{ steps.docker-build-args.outputs.result }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,11 @@ on:
         required: false
         type: string
         default: ''
+      start_npm:
+        description: 'Start npm'
+        required: false
+        type: boolean
+        default: false
 jobs:
   # Check tag setisfiy semantic versioning
   tag_check:
@@ -190,6 +195,13 @@ jobs:
       - name: Docker build and push ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
         if: ${{ !fromJson(steps.skip-build.outputs.skip) }}
         run: |
+        
+          if [[ "${{ inputs.start_npm }}" == true ]]; then
+            npm set @databox:registry=https://npm.pkg.github.com/databox
+            npm set //npm.pkg.github.com/:_authToken=${{ secrets.PACKAGES_READ_TOKEN }}
+            npm start
+          fi
+          
           docker buildx create --name DLC_builder --use --driver=docker-container
           docker buildx build \
             ${{ steps.docker-build-args.outputs.result }} \


### PR DESCRIPTION
Start npm based on input flag. This is needed for website to fully build assets in its build workflows. I have missed this because of assumptions all assets are built within the docker build step. But for website this is not the case because some assets are built by npm outside the docker build step. 

Slack  ref: https://databox.slack.com/archives/C0BLH359U/p1718174927685679