### PR TITLE
Create ECR repo if not exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,11 @@ jobs:
           echo "IMAGE=$image_name" >> $GITHUB_ENV
           echo "IMAGE_TAG=${{ needs.tag_check.outputs.semver }}-${{ matrix.platform }}" >> $GITHUB_ENV
           echo ECR image: $image_name:${{ needs.tag_check.outputs.semver }}-${{ matrix.platform }}
+      
+      - name: Create ECR repository if not exists
+        if: ${{ !fromJson(steps.skip-build.outputs.skip) }}
+        run: |
+          aws ecr describe-repositories --repository-names ${{ env.IMAGE }} || aws ecr create-repository --image-scanning-configuration scanOnPush=true --repository-name ${{ env.IMAGE }} 
 
       - name: Configure AWS Credentials
         if: ${{ !fromJson(steps.skip-build.outputs.skip) }}


### PR DESCRIPTION
Create an ECR repository if it does not exist yet... This is useful for new services deployed. There is no need for teams to ask the DevOps team to create an ECR repo prior first release...

[Slack ref](https://databox.slack.com/archives/C0BLH359U/p1718953184272089)