### PR TITLE
Add reusable Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-latest
+    runs-on: databox-arm64
     container:
       image: semgrep/semgrep
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,18 @@
+name: Semgrep
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: semgrep/ci
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v6
+      - run: semgrep scan --config auto


### PR DESCRIPTION
## Summary
- Adds a reusable Semgrep static analysis workflow using Community Edition
- Other repositories can call it via `uses: databox/.github/.github/workflows/semgrep.yml@master`
- Uses `semgrep scan --config auto` with the recommended ruleset from the Semgrep Registry